### PR TITLE
WIP: Added default return handler

### DIFF
--- a/main.py
+++ b/main.py
@@ -187,6 +187,7 @@ def index():
     if request.method == 'GET':
         internal_ip = socket.gethostbyname(socket.gethostname())
         return "Congratulations! Your API is working! You can now make requests to the API.\n\nEndpoint: " + internal_ip + ':5001/v1'
+    return ERROR_HANDLER(1212)  # Default return for any other methods
 @app.route('/v1/models')
 @limiter.limit("500 per minute")
 def models():

--- a/main.py
+++ b/main.py
@@ -182,8 +182,6 @@ AVAILABLE_MODELS.extend(SUBSET_OF_ONE_MIN_PERMITTED_MODELS)
 
 @app.route('/', methods=['GET', 'POST'])
 def index():
-    if request.method == 'POST':
-        return ERROR_HANDLER(1212)
     if request.method == 'GET':
         internal_ip = socket.gethostbyname(socket.gethostname())
         return "Congratulations! Your API is working! You can now make requests to the API.\n\nEndpoint: " + internal_ip + ':5001/v1'


### PR DESCRIPTION
Fix for issue #34 
The index route handler in [main.py](https://github.com/kokofixcomputers/1min-relay/blob/fe6527d0b61b4f046aeec38068cad154c264b6ef/main.py#L184) does not have a default handler for requests other than GET and POST. This commit adds it.