### PR TITLE
fix: improve error handling to include upstream 1min.ai error details

### DIFF
--- a/main.py
+++ b/main.py
@@ -467,12 +467,33 @@ def set_response_headers(response):
 def handle_1min_error(response):
     if response.status_code == 401:
         return ERROR_HANDLER(1020)
+    
+    # Try to extract a meaningful error message from 1min.ai's response
+    try:
+        error_json = response.json()
+        upstream_detail = (
+            error_json.get("message")
+            or error_json.get("error")
+            or error_json.get("detail")
+            or response.text[:500]
+        )
+    except (ValueError, AttributeError):
+        upstream_detail = response.text[:500] if response.text else "No response body"
+
     logger.error(
         "1min.ai request failed with status %s: %s",
         response.status_code,
-        response.text[:500]
+        upstream_detail
     )
-    return ERROR_HANDLER(response.status_code)
+
+    # Return a structured error that includes the upstream message
+    error_data = {
+        "message": f"1min.ai API error ({response.status_code}): {upstream_detail}",
+        "type": "upstream_error",
+        "param": None,
+        "code": f"upstream_{response.status_code}",
+    }
+    return jsonify({"error": error_data}), response.status_code
 
 def stream_response(response, request_data, model, prompt_tokens):
     """


### PR DESCRIPTION
## Problem

When 1min.ai returns an HTTP error (e.g. 400 Bad Request), the relay returns a generic error message like:

```json
{"error": {"message": "Unknown error", "type": "unknown_error", "param": null, "code": null}}
```

This makes it **impossible for users to diagnose** what went wrong — whether it's a deprecated API type, an invalid model ID, or a malformed request. Issues #72 and #65 are both examples of users hitting this wall.

## Fix

Modified `handle_1min_error()` to:

1. **Parse the upstream response** — extracts `message`, `error`, or `detail` fields from 1min.ai's JSON response
2. **Include upstream details in the error response** — users now see what 1min.ai actually reported
3. **Preserve the original HTTP status code** — returns 1min.ai's actual status code instead of always returning 400

### Before
```json
{"error": {"message": "Unknown error", "type": "unknown_error"}}
```

### After
```json
{"error": {"message": "1min.ai API error (400): UNIFY_CHAT_WITH_AI is required...", "type": "upstream_error", "code": "upstream_400"}}
```

## Related Issues

Fixes #72, Fixes #65