### PR TITLE
Add Hermes Safe Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 .DS_Store
+# Local Python/runtime artifacts
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+
+# Secrets / local env
+.env
+*.env
+secrets/

--- a/README.md
+++ b/README.md
@@ -88,3 +88,106 @@ Verification
   - curl -X GET http://localhost:5001/v1/models
 
 ### If you find this project useful, please consider starring the repository and supporting us through the provided donation or paid hosted options.
+
+## Hermes Safe Mode
+
+Hermes Safe Mode is a chat-only operating mode for using this relay behind Hermes Agent without exposing provider metadata, internal planning text, web-search chatter, conversation memory, or raw upstream payloads through OpenAI-compatible responses.
+
+Enable it with:
+
+```bash
+HERMES_SAFE_MODE=true
+ONE_MIN_AI_API_KEY=replace-with-runtime-secret
+```
+
+Do not commit real API keys or runtime secrets to Git. Provide `ONE_MIN_AI_API_KEY` only through your runtime environment or secret manager.
+
+### Safe defaults
+
+When `HERMES_SAFE_MODE=true`, these options default to `true` unless explicitly set otherwise:
+
+- `FORCE_NON_STREAMING`
+- `SYNTHETIC_SSE_WHEN_STREAM_REQUESTED`
+- `DISABLE_1MIN_WEB_SEARCH`
+- `DISABLE_1MIN_MEMORIES`
+- `DISABLE_1MIN_HISTORY`
+- `STATIC_MODELS_ONLY`
+- `SUPPRESS_UPSTREAM_METADATA`
+- `SANITIZE_ASSISTANT_OUTPUT`
+- `BLOCK_REASONING_LEAKS`
+- `PERMIT_MODELS_FROM_SUBSET_ONLY`
+
+Default allowed models in Safe Mode:
+
+```text
+gpt-4o-mini,gpt-4o,gpt-5.4-mini,mistral-nemo
+```
+
+Default model in Safe Mode:
+
+```text
+gpt-4o-mini
+```
+
+### Environment variables
+
+Supported Safe Mode variables:
+
+- `ONE_MIN_AI_API_KEY`: upstream 1min.ai API key supplied by runtime environment.
+- `HOST`: bind host. Default: `0.0.0.0`.
+- `PORT`: bind port. Default: `5001`.
+- `HERMES_SAFE_MODE`: enables Hermes-safe defaults.
+- `FORCE_NON_STREAMING`: never call the native 1min.ai streaming URL.
+- `SYNTHETIC_SSE_WHEN_STREAM_REQUESTED`: return synthetic OpenAI-compatible SSE when clients request `stream=true`.
+- `DISABLE_1MIN_WEB_SEARCH`: forces `webSearch=false`, `numOfSite=0`, `maxWord=0`.
+- `DISABLE_1MIN_MEMORIES`: forces `withMemories=false` and omits conversation IDs.
+- `DISABLE_1MIN_HISTORY`: forces `isMixed=false` and `historyMessageLimit=0`.
+- `STATIC_MODELS_ONLY`: returns only local static model metadata from the allowed subset.
+- `SUPPRESS_UPSTREAM_METADATA`: suppresses raw upstream metadata from responses.
+- `SANITIZE_ASSISTANT_OUTPUT`: returns only final assistant content.
+- `BLOCK_REASONING_LEAKS`: blocks unsafe reasoning, planning, tool/debug, provider, and raw `aiRecord` leakage.
+- `SUBSET_OF_ONE_MIN_PERMITTED_MODELS`: comma-separated model allowlist.
+- `PERMIT_MODELS_FROM_SUBSET_ONLY`: blocks non-allowlisted models before upstream calls.
+- `DEFAULT_MODEL`: model used when the client omits `model`.
+- `MAX_PROMPT_CHARS`: optional flattened prompt length cap. `0` means no cap.
+- `REQUEST_TIMEOUT_SECONDS`: upstream request timeout. Default: `120`.
+- `LOG_PROMPTS`: default `false`; do not enable in Hermes production contexts.
+- `LOG_RESPONSES`: default `false`; do not enable in Hermes production contexts.
+- `LOG_SECRETS`: default `false`; the app still redacts secret-like logging fields.
+- `ALLOW_CLIENT_API_KEY_FALLBACK`: default `false`; only forwards client bearer tokens upstream when explicitly enabled.
+
+### Docker Compose example
+
+```yaml
+services:
+  1min-relay:
+    image: kokofixcomputers/1min-relay:latest
+    ports:
+      - "5001:5001"
+    environment:
+      - HERMES_SAFE_MODE=true
+      - ONE_MIN_AI_API_KEY=${ONE_MIN_AI_API_KEY}
+      - HOST=0.0.0.0
+      - PORT=5001
+      - SUBSET_OF_ONE_MIN_PERMITTED_MODELS=gpt-4o-mini,gpt-4o,gpt-5.4-mini,mistral-nemo
+      - DEFAULT_MODEL=gpt-4o-mini
+      - LOG_PROMPTS=false
+      - LOG_RESPONSES=false
+      - LOG_SECRETS=false
+```
+
+### Safe Mode limitations
+
+Phase 1 is chat only. In `HERMES_SAFE_MODE=true`, `/v1/images/generations` returns an OpenAI-compatible `unsupported_in_hermes_safe_mode` error. Vision attachments are not sent upstream in Safe Mode.
+
+Native upstream streaming is disabled by default in Safe Mode. If a client requests `stream=true`, the relay calls 1min.ai non-streaming, sanitizes the final text, and emits synthetic OpenAI-compatible SSE chunks ending with `data: [DONE]`.
+
+### Hermes isolated test plan
+
+Run only local tests with mocks. Do not use real API keys and do not call Hermes runtime, Telegram, broker, trading, investment, Portainer, Docker runtime containers, `/srv/stacks`, `/srv/runtime`, or `/srv/secrets`.
+
+```bash
+python3 -m py_compile main.py
+python3 -m unittest discover -s tests -v
+```
+

--- a/main.py
+++ b/main.py
@@ -8,18 +8,41 @@ import uuid
 import warnings
 from io import BytesIO
 
-import coloredlogs
+try:
+    import coloredlogs
+except ImportError:
+    coloredlogs = None
 import requests
-import tiktoken
+try:
+    import tiktoken
+except ImportError:
+    tiktoken = None
 from flask import Flask, Response, jsonify, make_response, request
-from flask_limiter import Limiter
-from flask_limiter.util import get_remote_address
-from pymemcache.client.base import Client
-from waitress import serve
+try:
+    from flask_limiter import Limiter
+    from flask_limiter.util import get_remote_address
+except ImportError:
+    Limiter = None
 
-from mistral_common.protocol.instruct.messages import UserMessage
-from mistral_common.protocol.instruct.request import ChatCompletionRequest
-from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+    def get_remote_address():
+        return request.remote_addr or "127.0.0.1"
+try:
+    from pymemcache.client.base import Client
+except ImportError:
+    Client = None
+try:
+    from waitress import serve
+except ImportError:
+    def serve(app, host="0.0.0.0", port=5001):
+        app.run(host=host, port=port)
+try:
+    from mistral_common.protocol.instruct.messages import UserMessage
+    from mistral_common.protocol.instruct.request import ChatCompletionRequest
+    from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+except ImportError:
+    UserMessage = None
+    ChatCompletionRequest = None
+    MistralTokenizer = None
 
 try:
     import printedcolors
@@ -33,11 +56,68 @@ except Exception:
 warnings.filterwarnings("ignore", category=UserWarning, module="flask_limiter.extension")
 
 logger = logging.getLogger("relay")
-coloredlogs.install(level=os.getenv("LOG_LEVEL", "INFO"), logger=logger)
+if coloredlogs is not None:
+    coloredlogs.install(level=os.getenv("LOG_LEVEL", "INFO"), logger=logger)
+else:
+    logging.basicConfig(level=os.getenv("LOG_LEVEL", "INFO"))
+
+
+def env_bool(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+def env_int(name: str, default: int, minimum: int | None = None) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw.strip())
+    except (TypeError, ValueError):
+        return default
+    if minimum is not None and value < minimum:
+        return default
+    return value
+
+
+def env_csv(name: str, default: str) -> list[str]:
+    raw = os.getenv(name, default)
+    seen = set()
+    values = []
+    for item in raw.split(","):
+        value = item.strip()
+        if value and value not in seen:
+            values.append(value)
+            seen.add(value)
+    return values
+
 
 APP_NAME = os.getenv("APP_NAME", "relay")
-PORT = int(os.getenv("PORT", os.getenv("APP_PORT", 5001)))
 HOST = os.getenv("HOST", os.getenv("APP_HOST", "0.0.0.0"))
+PORT = env_int("PORT", env_int("APP_PORT", 5001), minimum=1)
+
+HERMES_SAFE_MODE = env_bool("HERMES_SAFE_MODE", False)
+FORCE_NON_STREAMING = env_bool("FORCE_NON_STREAMING", HERMES_SAFE_MODE)
+SYNTHETIC_SSE_WHEN_STREAM_REQUESTED = env_bool("SYNTHETIC_SSE_WHEN_STREAM_REQUESTED", HERMES_SAFE_MODE)
+DISABLE_1MIN_WEB_SEARCH = env_bool("DISABLE_1MIN_WEB_SEARCH", HERMES_SAFE_MODE)
+DISABLE_1MIN_MEMORIES = env_bool("DISABLE_1MIN_MEMORIES", HERMES_SAFE_MODE)
+DISABLE_1MIN_HISTORY = env_bool("DISABLE_1MIN_HISTORY", HERMES_SAFE_MODE)
+STATIC_MODELS_ONLY = env_bool("STATIC_MODELS_ONLY", HERMES_SAFE_MODE)
+SUPPRESS_UPSTREAM_METADATA = env_bool("SUPPRESS_UPSTREAM_METADATA", HERMES_SAFE_MODE)
+SANITIZE_ASSISTANT_OUTPUT = env_bool("SANITIZE_ASSISTANT_OUTPUT", HERMES_SAFE_MODE)
+BLOCK_REASONING_LEAKS = env_bool("BLOCK_REASONING_LEAKS", HERMES_SAFE_MODE)
+PERMIT_MODELS_FROM_SUBSET_ONLY = env_bool("PERMIT_MODELS_FROM_SUBSET_ONLY", HERMES_SAFE_MODE)
+MAX_PROMPT_CHARS = env_int("MAX_PROMPT_CHARS", 0, minimum=0)
+REQUEST_TIMEOUT_SECONDS = env_int("REQUEST_TIMEOUT_SECONDS", 120, minimum=1)
+LOG_PROMPTS = env_bool("LOG_PROMPTS", False)
+LOG_RESPONSES = env_bool("LOG_RESPONSES", False)
+LOG_SECRETS = env_bool("LOG_SECRETS", False)
+ALLOW_CLIENT_API_KEY_FALLBACK = env_bool("ALLOW_CLIENT_API_KEY_FALLBACK", False)
+ONE_MIN_AI_API_KEY = os.getenv("ONE_MIN_AI_API_KEY", "").strip()
+DEFAULT_ALLOWED_MODELS = "gpt-4o-mini,gpt-4o,gpt-5.4-mini,mistral-nemo"
+DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "gpt-4o-mini" if HERMES_SAFE_MODE else "mistral-nemo").strip()
 
 API_BASE = os.getenv("ONE_MIN_API_BASE", "https://api.1min.ai/api")
 CHAT_URL = os.getenv("ONE_MIN_CHAT_API_URL", f"{API_BASE}/chat-with-ai")
@@ -106,23 +186,37 @@ IMAGE_MODELS = {
     "black-forest-labs/flux-schnell",
 }
 
-MODEL_SUBSET = [
-    m.strip()
-    for m in os.getenv("SUBSET_OF_ONE_MIN_PERMITTED_MODELS", "mistral-nemo,gpt-4o,deepseek-chat").split(",")
-    if m.strip()
-]
-STRICT_MODELS = os.getenv("PERMIT_MODELS_FROM_SUBSET_ONLY", "false").lower() == "true"
-MODELS = MODEL_SUBSET if STRICT_MODELS else OLD_MODEL_LIST
+MODEL_SUBSET = env_csv(
+    "SUBSET_OF_ONE_MIN_PERMITTED_MODELS",
+    DEFAULT_ALLOWED_MODELS if HERMES_SAFE_MODE else "mistral-nemo,gpt-4o,deepseek-chat",
+)
+STRICT_MODELS = PERMIT_MODELS_FROM_SUBSET_ONLY
+MODELS = MODEL_SUBSET if (STRICT_MODELS or STATIC_MODELS_ONLY) else OLD_MODEL_LIST
 
 MEM_HOST = os.getenv("MEMCACHED_HOST", os.getenv("MEM_HOST", "memcached"))
-MEM_PORT = int(os.getenv("MEMCACHED_PORT", os.getenv("MEM_PORT", 11211)))
+MEM_PORT = env_int("MEMCACHED_PORT", env_int("MEM_PORT", 11211), minimum=1)
 
 app = Flask(__name__)
 
 
+def safe_log(level: int, event: str, **fields):
+    safe_fields = {}
+    for key, value in fields.items():
+        lowered = key.lower()
+        if any(token in lowered for token in ("key", "secret", "authorization", "prompt", "response", "airecord", "payload")):
+            safe_fields[key] = "[redacted]"
+        elif isinstance(value, str) and len(value) > 120:
+            safe_fields[key] = value[:117] + "..."
+        else:
+            safe_fields[key] = value
+    logger.log(level, "%s %s", event, safe_fields if safe_fields else "")
+
+
 def memcached_ok(host: str = MEM_HOST, port: int = MEM_PORT) -> bool:
+    if Client is None:
+        return False
     try:
-        c = Client((host, port))
+        c = Client((host, port), connect_timeout=0.2, timeout=0.2)
         c.set("relay_test", b"1")
         ok = c.get("relay_test") == b"1"
         c.delete("relay_test")
@@ -131,21 +225,32 @@ def memcached_ok(host: str = MEM_HOST, port: int = MEM_PORT) -> bool:
         return False
 
 
-if memcached_ok():
+class _NoopLimiter:
+    def limit(self, _rule):
+        def decorator(func):
+            return func
+        return decorator
+
+
+if Limiter is None:
+    limiter = _NoopLimiter()
+elif memcached_ok():
     limiter = Limiter(get_remote_address, app=app, storage_uri=f"memcached://{MEM_HOST}:{MEM_PORT}")
 else:
     limiter = Limiter(get_remote_address, app=app)
-    logger.warning("Memcached unavailable; using in-memory rate limiting.")
+    safe_log(logging.WARNING, "rate_limit_storage_fallback", storage="memory")
 
 
 def token_count(text: str, model: str = "gpt-4") -> int:
     try:
-        if model.startswith("mistral"):
+        if model.startswith("mistral") and MistralTokenizer is not None:
             tok = MistralTokenizer.from_model("open-mistral-nemo")
             req = ChatCompletionRequest(messages=[UserMessage(content=text)], model="open-mistral-nemo")
             return len(tok.encode_chat_completion(req).tokens)
-        enc = tiktoken.encoding_for_model(model if model in {"gpt-3.5-turbo", "gpt-4"} else "gpt-4")
-        return len(enc.encode(text))
+        if tiktoken is not None:
+            enc = tiktoken.encoding_for_model(model if model in {"gpt-3.5-turbo", "gpt-4"} else "gpt-4")
+            return len(enc.encode(text))
+        return len(text.split())
     except Exception:
         return len(text.split())
 
@@ -153,16 +258,20 @@ def token_count(text: str, model: str = "gpt-4") -> int:
 def error(code: int, model: str | None = None, key: str | None = None):
     mapping = {
         1002: ("The model does not exist.", "invalid_request_error", "model_not_found", 400),
-        1020: (f"Incorrect API key provided: {key}.", "authentication_error", "invalid_api_key", 401),
+        1003: ("The requested model is not allowed by this relay.", "invalid_request_error", "model_not_allowed", 400),
+        1020: ("Incorrect API key provided.", "authentication_error", "invalid_api_key", 401),
         1021: ("Invalid Authentication", "invalid_request_error", None, 401),
         1212: ("Incorrect Endpoint. Please use the /v1/chat/completions endpoint.", "invalid_request_error", "model_not_supported", 400),
         1044: ("This model does not support image inputs.", "invalid_request_error", "model_not_supported", 400),
         1412: ("No message provided.", "invalid_request_error", "invalid_request_error", 400),
         1423: ("No content in last message.", "invalid_request_error", "invalid_request_error", 400),
         1405: ("Method Not Allowed", "invalid_request_error", None, 405),
+        1501: ("The upstream provider returned an error.", "upstream_error", "upstream_error", 502),
+        1502: ("The upstream provider response could not be used safely.", "upstream_output_safety_error", "unsafe_reasoning_leak", 502),
+        1503: ("This endpoint is unsupported in Hermes Safe Mode.", "invalid_request_error", "unsupported_in_hermes_safe_mode", 400),
     }
     msg, typ, err_code, http = mapping.get(code, ("Unknown error", "unknown_error", None, 400))
-    if model:
+    if model and code == 1002:
         msg = msg.replace("does not exist.", f"does not exist: {model}.")
     payload = {"error": {"message": msg, "type": typ, "param": None, "code": err_code}}
     return jsonify(payload), http
@@ -176,55 +285,56 @@ def cors():
     return resp, 204
 
 
-def get_api_key():
+def get_client_api_key():
     h = request.headers.get("Authorization", "")
     if not h.startswith("Bearer "):
         return None
     return h.split(" ", 1)[1].strip() or None
 
 
+def get_api_key():
+    return get_client_api_key()
+
+
+def get_upstream_api_key():
+    if ONE_MIN_AI_API_KEY:
+        return ONE_MIN_AI_API_KEY
+    if ALLOW_CLIENT_API_KEY_FALLBACK:
+        return get_client_api_key()
+    return None
+
+
 def normalize_text(content):
     if isinstance(content, list):
         parts = []
         for item in content:
-            if isinstance(item, dict):
-                if "text" in item:
-                    txt = item["text"]
-                    parts.append("".join(txt) if isinstance(txt, list) else str(txt))
+            if isinstance(item, dict) and "text" in item:
+                txt = item["text"]
+                parts.append("".join(txt) if isinstance(txt, list) else str(txt))
         return "\n".join(parts).strip()
     return str(content).strip() if content is not None else ""
 
 
 def build_prompt(messages, new_input=""):
-    lines = ["Conversation History:\n"]
+    lines = []
     for msg in messages:
-        role = str(msg.get("role", "")).capitalize()
+        role = str(msg.get("role", "user")).strip().lower() or "user"
         content = normalize_text(msg.get("content", ""))
         lines.append(f"{role}: {content}")
-    if messages:
-        lines.append("Respond like normal. Do not add role labels.")
-        lines.append("User Message:\n")
-    lines.append(new_input)
-    return "\n".join(lines)
+    extra = normalize_text(new_input)
+    if extra:
+        lines.append(f"user: {extra}")
+    prompt = "\n".join(lines)
+    if MAX_PROMPT_CHARS and len(prompt) > MAX_PROMPT_CHARS:
+        prompt = prompt[-MAX_PROMPT_CHARS:]
+    return prompt
 
 
 def upstream_error(resp):
     if resp.status_code == 401:
         return error(1020)
-    try:
-        j = resp.json()
-        detail = j.get("message") or j.get("error") or j.get("detail") or resp.text[:500]
-    except Exception:
-        detail = resp.text[:500] if getattr(resp, "text", None) else "No response body"
-    payload = {
-        "error": {
-            "message": f"1min.ai API error ({resp.status_code}): {detail}",
-            "type": "upstream_error",
-            "param": None,
-            "code": f"upstream_{resp.status_code}",
-        }
-    }
-    return jsonify(payload), resp.status_code
+    safe_log(logging.WARNING, "upstream_error", status_code=getattr(resp, "status_code", None))
+    return error(1501)
 
 
 def set_headers(resp):
@@ -238,17 +348,85 @@ def upload_image(url: str, headers: dict) -> str:
         data = base64.b64decode(url.split(",", 1)[1])
         fileobj = BytesIO(data)
     else:
-        r = requests.get(url, timeout=60)
+        r = requests.get(url, timeout=REQUEST_TIMEOUT_SECONDS)
         r.raise_for_status()
         fileobj = BytesIO(r.content)
     files = {"asset": (f"relay-{uuid.uuid4()}", fileobj, "image/png")}
-    r = requests.post(ASSET_URL, files=files, headers=headers, timeout=60)
+    r = requests.post(ASSET_URL, files=files, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
     r.raise_for_status()
     return r.json()["fileContent"]["path"]
 
 
+UNSAFE_REASONING_MARKERS = (
+    "considering response to user",
+    "the user is looking for",
+    "i need to",
+    "we need to answer",
+    "analysis",
+    "chain of thought",
+    "internal reasoning",
+    "scratchpad",
+    "tool call",
+    "debug",
+    "provider details",
+    "raw airecord",
+)
+
+
+def extract_assistant_text(resp_json) -> str:
+    if isinstance(resp_json, dict):
+        try:
+            result = resp_json["aiRecord"]["aiRecordDetail"]["resultObject"]
+            if isinstance(result, list) and result:
+                return str(result[0])
+            return str(result)
+        except (KeyError, TypeError):
+            pass
+        for key in ("content", "text", "message", "result"):
+            value = resp_json.get(key)
+            if isinstance(value, str):
+                return value
+    raise ValueError("missing assistant content")
+
+
+def sanitize_assistant_text(text: str) -> str:
+    cleaned = str(text or "").strip()
+    if not SANITIZE_ASSISTANT_OUTPUT:
+        return cleaned
+    if BLOCK_REASONING_LEAKS:
+        lowered = cleaned.lower()
+        if any(marker in lowered for marker in UNSAFE_REASONING_MARKERS):
+            raise ValueError("unsafe reasoning leak")
+    return cleaned
+
+
+def build_chat_payload(model: str, prompt: str) -> dict:
+    payload = {
+        "type": "UNIFY_CHAT_WITH_AI",
+        "model": model,
+        "promptObject": {"prompt": prompt},
+    }
+    if HERMES_SAFE_MODE:
+        payload["promptObject"]["settings"] = {
+            "webSearchSettings": {
+                "webSearch": False if DISABLE_1MIN_WEB_SEARCH else True,
+                "numOfSite": 0 if DISABLE_1MIN_WEB_SEARCH else 1,
+                "maxWord": 0 if DISABLE_1MIN_WEB_SEARCH else 500,
+            },
+            "historySettings": {
+                "isMixed": False if DISABLE_1MIN_HISTORY else True,
+                "historyMessageLimit": 0 if DISABLE_1MIN_HISTORY else 10,
+            },
+            "withMemories": False if DISABLE_1MIN_MEMORIES else True,
+        }
+    return payload
+
+
 def transform_chat(resp_json, model: str, prompt_tokens: int):
-    text = resp_json["aiRecord"]["aiRecordDetail"]["resultObject"][0]
+    try:
+        text = sanitize_assistant_text(extract_assistant_text(resp_json))
+    except ValueError:
+        return None
     comp_tokens = token_count(text, model)
     return {
         "id": f"chatcmpl-{uuid.uuid4()}",
@@ -268,6 +446,49 @@ def transform_chat(resp_json, model: str, prompt_tokens: int):
             "total_tokens": prompt_tokens + comp_tokens,
         },
     }
+
+
+def synthetic_sse(text: str, model: str, prompt_tokens: int):
+    stream_id = f"chatcmpl-{uuid.uuid4()}"
+    created = int(time.time())
+    yield "data: " + json.dumps(
+        {
+            "id": stream_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+        },
+        ensure_ascii=False,
+    ) + "\n\n"
+    if text:
+        yield "data: " + json.dumps(
+            {
+                "id": stream_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": None}],
+            },
+            ensure_ascii=False,
+        ) + "\n\n"
+    comp_tokens = token_count(text, model)
+    yield "data: " + json.dumps(
+        {
+            "id": stream_id,
+            "object": "chat.completion.chunk",
+            "created": created,
+            "model": model,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": comp_tokens,
+                "total_tokens": prompt_tokens + comp_tokens,
+            },
+        },
+        ensure_ascii=False,
+    ) + "\n\n"
+    yield "data: [DONE]\n\n"
 
 
 def stream_chat(resp, model: str, prompt_tokens: int):
@@ -341,7 +562,8 @@ def index():
 @app.route("/v1/models", methods=["GET"])
 @limiter.limit("500 per minute")
 def models():
-    data = [{"id": m, "object": "model", "owned_by": "1minai", "created": 1727389042} for m in MODELS]
+    model_ids = MODEL_SUBSET if STATIC_MODELS_ONLY else MODELS
+    data = [{"id": m, "object": "model", "owned_by": "1minai", "created": 1727389042} for m in model_ids]
     return jsonify({"data": data, "object": "list"})
 
 
@@ -351,7 +573,7 @@ def chat():
     if request.method == "OPTIONS":
         return cors()
 
-    api_key = get_api_key()
+    api_key = get_upstream_api_key()
     if not api_key:
         return error(1021)
 
@@ -364,16 +586,16 @@ def chat():
     if not last:
         return error(1423)
 
-    model = data.get("model", "mistral-nemo")
-    if STRICT_MODELS and model not in MODELS:
-        return error(1002, model)
+    model = data.get("model") or DEFAULT_MODEL
+    if STRICT_MODELS and model not in MODEL_SUBSET:
+        return error(1003, model)
 
     headers = {"API-KEY": api_key, "Content-Type": "application/json"}
     prompt = build_prompt(messages, data.get("new_input", ""))
 
     attachments = None
     content = messages[-1].get("content")
-    if isinstance(content, list):
+    if isinstance(content, list) and not HERMES_SAFE_MODE:
         if model not in VISION_MODELS:
             return error(1044, model)
         image_paths = []
@@ -387,32 +609,39 @@ def chat():
             if "image_url" in item:
                 try:
                     image_paths.append(upload_image(item["image_url"]["url"], headers))
-                except Exception as e:
-                    logger.exception("image upload failed: %s", e)
+                except Exception:
+                    safe_log(logging.WARNING, "image_upload_failed")
         if image_paths:
             attachments = {"images": image_paths}
         if text_parts:
             prompt = build_prompt(messages[:-1] + [{"role": "user", "content": "\n".join(text_parts)}], data.get("new_input", ""))
 
+    if LOG_PROMPTS and not HERMES_SAFE_MODE:
+        safe_log(logging.INFO, "prompt_length", chars=len(prompt))
+
     prompt_tokens = token_count(prompt, model)
-    payload = {
-        "type": "UNIFY_CHAT_WITH_AI",
-        "model": model,
-        "promptObject": {"prompt": prompt},
-    }
+    payload = build_chat_payload(model, prompt)
     if attachments:
         payload["promptObject"]["attachments"] = attachments
 
-    if not data.get("stream", False):
-        r = requests.post(CHAT_URL, json=payload, headers=headers, timeout=120)
+    client_requested_stream = bool(data.get("stream", False))
+    upstream_stream = client_requested_stream and not FORCE_NON_STREAMING and not SANITIZE_ASSISTANT_OUTPUT and not BLOCK_REASONING_LEAKS
+
+    if not upstream_stream:
+        r = requests.post(CHAT_URL, json=payload, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
         if r.status_code != 200:
             return upstream_error(r)
         out = transform_chat(r.json(), model, prompt_tokens)
+        if out is None:
+            return error(1502)
+        if client_requested_stream and SYNTHETIC_SSE_WHEN_STREAM_REQUESTED:
+            text = out["choices"][0]["message"]["content"]
+            return Response(synthetic_sse(text, model, prompt_tokens), content_type="text/event-stream")
         resp = make_response(jsonify(out), 200)
         set_headers(resp)
         return resp
 
-    r = requests.post(STREAM_URL, data=json.dumps(payload), headers=headers, stream=True, timeout=120)
+    r = requests.post(STREAM_URL, data=json.dumps(payload), headers=headers, stream=True, timeout=REQUEST_TIMEOUT_SECONDS)
     if r.status_code != 200:
         return upstream_error(r)
     return Response(stream_chat(r, model, prompt_tokens), content_type="text/event-stream")
@@ -423,8 +652,10 @@ def chat():
 def images():
     if request.method == "OPTIONS":
         return cors()
+    if HERMES_SAFE_MODE:
+        return error(1503)
 
-    api_key = get_api_key()
+    api_key = get_upstream_api_key()
     if not api_key:
         return error(1021)
 
@@ -449,22 +680,27 @@ def images():
     headers = {"API-KEY": api_key, "Content-Type": "application/json"}
 
     try:
-        r = requests.post(f"{FEATURES_URL}?isStreaming=false", json=payload, headers=headers, timeout=120)
+        r = requests.post(f"{FEATURES_URL}?isStreaming=false", json=payload, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
         r.raise_for_status()
         urls = r.json()["aiRecord"]["aiRecordDetail"]["resultObject"]
         return jsonify({"created": int(time.time()), "data": [{"url": u} for u in urls]})
-    except Exception as e:
-        logger.exception("image generation failed: %s", e)
+    except Exception:
+        safe_log(logging.WARNING, "image_generation_failed")
         return error(1044, model)
 
 
-if __name__ == "__main__":
+def run_server():
     ip = socket.gethostbyname(socket.gethostname())
-    pub = requests.get("https://api.ipify.org", timeout=10).text
+    public_ip = None
+    if not HERMES_SAFE_MODE:
+        try:
+            public_ip = requests.get("https://api.ipify.org", timeout=10).text
+        except Exception:
+            public_ip = "unavailable"
 
-    # Startup banner (simple “ad”)
-    logger.info(
-        f"""{printedcolors.Color.fg.lightcyan}
+    if not HERMES_SAFE_MODE:
+        logger.info(
+            f"""{printedcolors.Color.fg.lightcyan}
 ====================================================
 Enjoying this self-hosted relay?
 You can get a hosted, managed version at:
@@ -473,16 +709,15 @@ with extra features like video generation,
 failover nodes, and more.
 ====================================================
 {printedcolors.Color.reset}"""
-    )
+        )
 
-    logger.info(
-        f"""{printedcolors.Color.fg.lightcyan}
-Server ready:
-Internal IP: {ip}:{PORT}
-Public IP: {pub}
-OpenAI-compatible endpoint:
-{ip}:{PORT}/v1
-{printedcolors.Color.reset}"""
-    )
+    if public_ip:
+        logger.info("Server ready: internal=%s:%s public=%s endpoint=%s:%s/v1", ip, PORT, public_ip, ip, PORT)
+    else:
+        logger.info("Server ready: internal=%s:%s endpoint=%s:%s/v1", ip, PORT, ip, PORT)
 
-    serve(app, host=HOST, port=int(os.getenv("THREADS", "6")))
+    serve(app, host=HOST, port=PORT)
+
+
+if __name__ == "__main__":
+    run_server()

--- a/tests/test_hermes_safe.py
+++ b/tests/test_hermes_safe.py
@@ -1,0 +1,175 @@
+import importlib
+import os
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+
+SAFE_ENV = {
+    "HERMES_SAFE_MODE": "true",
+    "ONE_MIN_AI_API_KEY": "test-upstream-key",
+    "SUBSET_OF_ONE_MIN_PERMITTED_MODELS": "gpt-4o-mini,gpt-4o,gpt-5.4-mini,mistral-nemo",
+    "DEFAULT_MODEL": "gpt-4o-mini",
+    "PORT": "5019",
+}
+
+
+def load_main(extra_env=None):
+    env = SAFE_ENV.copy()
+    if extra_env:
+        env.update(extra_env)
+    for key in [
+        "HERMES_SAFE_MODE",
+        "ONE_MIN_AI_API_KEY",
+        "SUBSET_OF_ONE_MIN_PERMITTED_MODELS",
+        "DEFAULT_MODEL",
+        "PORT",
+        "FORCE_NON_STREAMING",
+        "SYNTHETIC_SSE_WHEN_STREAM_REQUESTED",
+        "DISABLE_1MIN_WEB_SEARCH",
+        "DISABLE_1MIN_MEMORIES",
+        "DISABLE_1MIN_HISTORY",
+        "STATIC_MODELS_ONLY",
+        "PERMIT_MODELS_FROM_SUBSET_ONLY",
+        "ALLOW_CLIENT_API_KEY_FALLBACK",
+    ]:
+        os.environ.pop(key, None)
+    os.environ.update(env)
+    sys.modules.pop("main", None)
+    import main
+    return importlib.reload(main)
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError("upstream error")
+
+
+def ai_payload(text="Final answer"):
+    return {"aiRecord": {"aiRecordDetail": {"resultObject": [text]}}}
+
+
+class HermesSafeTests(unittest.TestCase):
+    def test_models_returns_static_allowed_models(self):
+        main = load_main()
+        client = main.app.test_client()
+
+        resp = client.get("/v1/models")
+
+        self.assertEqual(resp.status_code, 200)
+        ids = [item["id"] for item in resp.get_json()["data"]]
+        self.assertEqual(ids, ["gpt-4o-mini", "gpt-4o", "gpt-5.4-mini", "mistral-nemo"])
+
+    def test_model_not_allowed_blocks_before_upstream(self):
+        main = load_main()
+        client = main.app.test_client()
+        with patch.object(main.requests, "post") as post:
+            resp = client.post("/v1/chat/completions", json={"model": "not-allowed", "messages": [{"role": "user", "content": "hi"}]})
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()["error"]["code"], "model_not_allowed")
+        post.assert_not_called()
+
+    def test_non_stream_chat_uses_non_streaming_url(self):
+        main = load_main()
+        client = main.app.test_client()
+        fake = FakeResponse(payload=ai_payload())
+        with patch.object(main.requests, "post", return_value=fake) as post:
+            resp = client.post("/v1/chat/completions", json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]})
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(post.call_args.args[0], main.CHAT_URL)
+        self.assertNotEqual(post.call_args.args[0], main.STREAM_URL)
+
+    def test_stream_true_force_non_streaming_does_not_call_streaming_url(self):
+        main = load_main()
+        client = main.app.test_client()
+        fake = FakeResponse(payload=ai_payload())
+        with patch.object(main.requests, "post", return_value=fake) as post:
+            resp = client.post("/v1/chat/completions", json={"stream": True, "model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]})
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(post.call_args.args[0], main.CHAT_URL)
+        self.assertNotIn("isStreaming=true", post.call_args.args[0])
+
+    def test_stream_true_synthetic_sse_returns_openai_sse_and_done(self):
+        main = load_main()
+        client = main.app.test_client()
+        fake = FakeResponse(payload=ai_payload("Safe final"))
+        with patch.object(main.requests, "post", return_value=fake):
+            resp = client.post("/v1/chat/completions", json={"stream": True, "model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]})
+
+        body = resp.get_data(as_text=True)
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("text/event-stream", resp.content_type)
+        self.assertIn('"object": "chat.completion.chunk"', body)
+        self.assertIn("Safe final", body)
+        self.assertTrue(body.rstrip().endswith("data: [DONE]"))
+
+    def test_upstream_payload_forces_safe_settings_and_omits_conversation_id(self):
+        main = load_main()
+        client = main.app.test_client()
+        fake = FakeResponse(payload=ai_payload())
+        with patch.object(main.requests, "post", return_value=fake) as post:
+            resp = client.post("/v1/chat/completions", json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]})
+
+        self.assertEqual(resp.status_code, 200)
+        payload = post.call_args.kwargs["json"]
+        settings = payload["promptObject"]["settings"]
+        self.assertEqual(settings["webSearchSettings"], {"webSearch": False, "numOfSite": 0, "maxWord": 0})
+        self.assertFalse(settings["withMemories"])
+        self.assertEqual(settings["historySettings"], {"isMixed": False, "historyMessageLimit": 0})
+        self.assertNotIn("conversationId", str(payload))
+
+    def test_reasoning_leak_is_blocked(self):
+        main = load_main()
+        client = main.app.test_client()
+        fake = FakeResponse(payload=ai_payload("Considering response to user: hidden planning"))
+        with patch.object(main.requests, "post", return_value=fake):
+            resp = client.post("/v1/chat/completions", json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]})
+
+        body = resp.get_json()
+        self.assertEqual(resp.status_code, 502)
+        self.assertEqual(body["error"]["code"], "unsafe_reasoning_leak")
+        self.assertNotIn("hidden planning", str(body))
+
+    def test_upstream_error_does_not_expose_raw_body(self):
+        main = load_main()
+        client = main.app.test_client()
+        fake = FakeResponse(status_code=500, payload={"message": "raw provider secret payload"}, text="raw provider secret payload")
+        with patch.object(main.requests, "post", return_value=fake):
+            resp = client.post("/v1/chat/completions", json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]})
+
+        body = resp.get_json()
+        self.assertEqual(resp.status_code, 502)
+        self.assertEqual(body["error"]["code"], "upstream_error")
+        self.assertNotIn("raw provider secret payload", str(body))
+
+    def test_image_route_disabled_in_hermes_safe_mode(self):
+        main = load_main()
+        client = main.app.test_client()
+        resp = client.post("/v1/images/generations", json={"prompt": "x"})
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()["error"]["code"], "unsupported_in_hermes_safe_mode")
+
+    def test_run_server_uses_port_env(self):
+        main = load_main({"PORT": "5099"})
+        with patch.object(main.socket, "gethostbyname", return_value="127.0.0.1"), patch.object(main.socket, "gethostname", return_value="localhost"), patch.object(main, "serve") as serve:
+            main.run_server()
+
+        serve.assert_called_once()
+        self.assertEqual(serve.call_args.kwargs["port"], 5099)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Hermes Safe Mode for safe OpenAI-compatible 1min.ai relay usage.

Includes:
- static /v1/models support
- model allowlist
- ONE_MIN_AI_API_KEY env handling
- forced non-streaming upstream calls
- synthetic OpenAI-compatible SSE for stream=true
- disabled web search, memories and history in Safe Mode
- output sanitization and reasoning leak blocking
- generic safe upstream errors
- /v1/images/generations disabled in Safe Mode
- fixed server port handling
- unittest coverage for Hermes Safe Mode behavior

Validation:
- python -m py_compile main.py
- python -m unittest discover -s tests -v
- 10 tests passed